### PR TITLE
Исправлена ошибка с позиционированием кнопки мобильного меню

### DIFF
--- a/src/sass/layouts/_mobile-menu.scss
+++ b/src/sass/layouts/_mobile-menu.scss
@@ -1,5 +1,5 @@
 .menu-btn {
-  position: absolute;
+  position: fixed;
   top: 15px;
   right: 15px;
   @media screen and (min-width: 768px) {
@@ -39,14 +39,15 @@
 }
 
 .mobile-menu {
-  position: fixed;
+  position: absolute;
   display: none;
   top: 0;
   left: 0;
   width: 100%;
-  height: 100%;
+  height: 100vh;
   text-align: center;
   padding-top: 25px;
+
   // transition: transform 250ms cubic-bezier(0.4, 0, 0.2, 1);
 
   &.is-open {
@@ -86,7 +87,7 @@
 }
 
 .overlay {
-  position: absolute;
+  position: fixed;
   z-index: 80;
   width: 100%;
   min-height: 100vh;


### PR DESCRIPTION
Кнопка меню в открытом меню при прокрутке тоже прокручиволось. Исправил (position: fixed).
Не меняй на 100%, оставь в .mobile-menu {height: 100vh;}. Так правильно работает оверлей при прокрутке меню.